### PR TITLE
refs PMP2-495 : Update lib60870 version

### DIFF
--- a/all-plugins-ubuntu2004/fledge/buildContainerfile.yml
+++ b/all-plugins-ubuntu2004/fledge/buildContainerfile.yml
@@ -69,7 +69,7 @@ build_modules:
       version: v1.2.4
   - module: 
       name: lib60870-install.sh
-      version: v2.3.3
+      version: v2.3.6
   - module: 
       name: fledgepower-filter-spoperators_build.sh
       version: v1.0.0


### PR DESCRIPTION
Commit 514baac of lib60870 fixes abusive cpu usage on north-iec104 plugin.