### PR TITLE
Remove unsupported plugins for version v2.3.0

### DIFF
--- a/all-plugins-ubuntu2004/fledge/buildContainerfile.yml
+++ b/all-plugins-ubuntu2004/fledge/buildContainerfile.yml
@@ -57,16 +57,16 @@ build_modules:
       version: v1.2.1
   - module: 
       name: fledge-south-hnz_build.sh
-      version: v3.0.0
+      version: v3.0.1
   - module: 
       name: libhnz-install.sh
       version: v1.0.0
   - module: 
       name: fledge-south-iec104_build.sh
-      version: v1.3.1
+      version: v1.3.2
   - module: 
       name: fledge-north-iec104_build.sh
-      version: v1.2.3
+      version: v1.2.4
   - module: 
       name: lib60870-install.sh
       version: v2.3.3


### PR DESCRIPTION
Remove the following unsupported plugins :

- fledgepower-filter-tase2topivot
- fledge-south-tase2
- fledge-north-tase2
- fledge-north-opcua