### PR TITLE
Fix Fledge3.1 startup incompatibilities

### DIFF
--- a/all-plugins-ubuntu2404/fledge/importModules.sh
+++ b/all-plugins-ubuntu2404/fledge/importModules.sh
@@ -89,10 +89,10 @@ ctrl_pipeline_10="${n6_north_service_name}_to_${s2_south_service_name}"
 ctrl_pipeline_11="${n7_north_service_name}_to_${s2_south_service_name}"
 ctrl_pipeline_12="${n8_north_service_name}_to_${s2_south_service_name}"
 # Group 2.2
-ctrl_pipeline_9="${n5_north_service_name}_to_${s4_south_service_name}"
-ctrl_pipeline_10="${n6_north_service_name}_to_${s4_south_service_name}"
-ctrl_pipeline_11="${n7_north_service_name}_to_${s4_south_service_name}"
-ctrl_pipeline_12="${n8_north_service_name}_to_${s4_south_service_name}"
+ctrl_pipeline_13="${n5_north_service_name}_to_${s4_south_service_name}"
+ctrl_pipeline_14="${n6_north_service_name}_to_${s4_south_service_name}"
+ctrl_pipeline_15="${n7_north_service_name}_to_${s4_south_service_name}"
+ctrl_pipeline_16="${n8_north_service_name}_to_${s4_south_service_name}"
 
 # Group 1.1
 ctrl_filter_1_sp="${ctrl_pipeline_1}_source_to_pivot_filter"
@@ -281,15 +281,10 @@ curl -X PUT --data '{"value":"1"}' http://localhost:8081/fledge/category/PURGE_R
 curl -X PUT --data '{"value":"100000"}' http://localhost:8081/fledge/category/PURGE_READ/size
 
 # Create Notification plugins
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_1'","description":"'$notif_name_1' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"1","rule_config":{},"delivery_config":{}}'
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_2'","description":"'$notif_name_2' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"1","rule_config":{},"delivery_config":{}}'
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_3'","description":"'$notif_name_3' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"1","rule_config":{},"delivery_config":{}}'
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_4'","description":"'$notif_name_4' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"1","rule_config":{},"delivery_config":{}}'
-# Workaround for delay between notifications (we want 0 but Fledge does not allow it, and -1 is rejected at notification instance creation)
-curl -X PUT --data '{"retrigger_time":"-1"}' http://localhost:8081/fledge/category/$notif_name_1
-curl -X PUT --data '{"retrigger_time":"-1"}' http://localhost:8081/fledge/category/$notif_name_2
-curl -X PUT --data '{"retrigger_time":"-1"}' http://localhost:8081/fledge/category/$notif_name_3
-curl -X PUT --data '{"retrigger_time":"-1"}' http://localhost:8081/fledge/category/$notif_name_4
+curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_1'","description":"'$notif_name_1' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_2'","description":"'$notif_name_2' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_3'","description":"'$notif_name_3' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_4'","description":"'$notif_name_4' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
 
 # Restart Fledge as it is mandatory for control pipelines to work
 curl -X PUT http://localhost:8081/fledge/restart

--- a/all-plugins-ubuntu2404/fledge/importModules.sh
+++ b/all-plugins-ubuntu2404/fledge/importModules.sh
@@ -32,9 +32,9 @@
 
 curl_wrapper() {
     if  [ ! -z "$TOKEN" ]; then
-        curl $@ -H "authorization: $TOKEN"
+        curl "$@" -H "authorization: $TOKEN"
     else
-        curl $@
+        curl "$@"
     fi
 }
 

--- a/all-plugins-ubuntu2404/fledge/importModules.sh
+++ b/all-plugins-ubuntu2404/fledge/importModules.sh
@@ -30,6 +30,17 @@
 # PMP south |     s1      |     s3      ||     s2      |     s4      |
 # PA        |   p1 (HNZ)  |   p1 (104)  ||   p2 (HNZ)  |   p2 (104)  |
 
+curl_wrapper() {
+    if  [ ! -z "$TOKEN" ]; then
+        curl $@ -H "authorization: $TOKEN"
+    else
+        curl $@
+    fi
+}
+
+# Connection token in case login is required to use the api
+TOKEN=$1
+
 # Constants
 s1_south_service_name="hnzsouth_s1"
 s2_south_service_name="hnzsouth_s2"
@@ -132,159 +143,159 @@ ctrl_filter_16_sp="${ctrl_pipeline_16}_source_to_pivot_filter"
 ctrl_filter_16_pd="${ctrl_pipeline_16}_pivot_to_destination_filter"
 
 # Create service south
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s1_south_service_name'","type":"south","plugin":"hnz","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s2_south_service_name'","type":"south","plugin":"hnz","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s3_south_service_name'","type":"south","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s4_south_service_name'","type":"south","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s1_south_service_name'","type":"south","plugin":"hnz","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s2_south_service_name'","type":"south","plugin":"hnz","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s3_south_service_name'","type":"south","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$s4_south_service_name'","type":"south","plugin":"iec104","enabled":false}'
 
 # Create service north
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n1_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n2_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n3_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n4_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n5_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n6_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n7_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n8_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$snmp_north_service_name'","type":"north","plugin":"auditsnmp","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n1_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n2_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n3_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n4_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n5_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n6_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n7_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$n8_north_service_name'","type":"north","plugin":"iec104","enabled":false}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$snmp_north_service_name'","type":"north","plugin":"auditsnmp","enabled":false}'
 
 # Create service notification
-curl -sX POST http://localhost:8081/fledge/service -d '{"name":"'$name_service_notif'","type":"notification","enabled":true}'
+curl_wrapper -sX POST http://localhost:8081/fledge/service -d '{"name":"'$name_service_notif'","type":"notification","enabled":true}'
 
 # Create plugins (one instance of a given plugin for each service that will use it)
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_3'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_4'", "plugin": "'$plugin_4'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_5'", "plugin": "'$plugin_5'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_3'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_4'", "plugin": "'$plugin_4'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_5'", "plugin": "'$plugin_5'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s3_south_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s3_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s4_south_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s4_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n1_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n2_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n3_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n4_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n5_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n6_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n7_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n8_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_3'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_4'", "plugin": "'$plugin_4'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s1_south_service_name'_'$plugin_5'", "plugin": "'$plugin_5'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_3'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_4'", "plugin": "'$plugin_4'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s2_south_service_name'_'$plugin_5'", "plugin": "'$plugin_5'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s3_south_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s3_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s4_south_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$s4_south_service_name'_'$plugin_2'", "plugin": "'$plugin_2'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n1_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n2_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n3_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n4_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n5_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n6_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n7_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$n8_north_service_name'_'$plugin_1'", "plugin": "'$plugin_1'"}'
 # Group 1.1
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_1_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_1_pd'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_2_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_2_pd'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_3_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_3_pd'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_4_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_4_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_1_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_1_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_2_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_2_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_3_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_3_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_4_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_4_pd'", "plugin": "'$plugin_3'"}'
 # Group 1.2
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_5_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_5_pd'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_6_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_6_pd'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_7_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_7_pd'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_8_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_8_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_5_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_5_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_6_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_6_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_7_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_7_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_8_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_8_pd'", "plugin": "'$plugin_1'"}'
 # Group 2.1
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_9_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_9_pd'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_10_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_10_pd'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_11_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_11_pd'", "plugin": "'$plugin_3'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_12_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_12_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_9_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_9_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_10_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_10_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_11_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_11_pd'", "plugin": "'$plugin_3'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_12_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_12_pd'", "plugin": "'$plugin_3'"}'
 # Group 2.2
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_13_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_13_pd'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_14_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_14_pd'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_15_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_15_pd'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_16_sp'", "plugin": "'$plugin_1'"}'
-curl -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_16_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_13_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_13_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_14_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_14_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_15_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_15_pd'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_16_sp'", "plugin": "'$plugin_1'"}'
+curl_wrapper -X POST http://localhost:8081/fledge/filter -d '{"name": "'$ctrl_filter_16_pd'", "plugin": "'$plugin_1'"}'
 
 # Create of south pipelines
-curl -X PUT http://localhost:8081/fledge/filter/$s1_south_service_name/pipeline -d  '{"pipeline": ["'$s1_south_service_name'_'$plugin_3'", "'$s1_south_service_name'_'$plugin_2'", "'$s1_south_service_name'_'$plugin_4'", "'$s1_south_service_name'_'$plugin_5'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$s2_south_service_name/pipeline -d  '{"pipeline": ["'$s2_south_service_name'_'$plugin_3'", "'$s2_south_service_name'_'$plugin_2'", "'$s2_south_service_name'_'$plugin_4'", "'$s2_south_service_name'_'$plugin_5'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$s3_south_service_name/pipeline -d  '{"pipeline": ["'$s3_south_service_name'_'$plugin_1'", "'$s3_south_service_name'_'$plugin_2'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$s4_south_service_name/pipeline -d  '{"pipeline": ["'$s4_south_service_name'_'$plugin_1'", "'$s4_south_service_name'_'$plugin_2'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$s1_south_service_name/pipeline -d  '{"pipeline": ["'$s1_south_service_name'_'$plugin_3'", "'$s1_south_service_name'_'$plugin_2'", "'$s1_south_service_name'_'$plugin_4'", "'$s1_south_service_name'_'$plugin_5'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$s2_south_service_name/pipeline -d  '{"pipeline": ["'$s2_south_service_name'_'$plugin_3'", "'$s2_south_service_name'_'$plugin_2'", "'$s2_south_service_name'_'$plugin_4'", "'$s2_south_service_name'_'$plugin_5'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$s3_south_service_name/pipeline -d  '{"pipeline": ["'$s3_south_service_name'_'$plugin_1'", "'$s3_south_service_name'_'$plugin_2'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$s4_south_service_name/pipeline -d  '{"pipeline": ["'$s4_south_service_name'_'$plugin_1'", "'$s4_south_service_name'_'$plugin_2'"]}'
 
 # Create of north pipelines
-curl -X PUT http://localhost:8081/fledge/filter/$n1_north_service_name/pipeline -d  '{"pipeline": ["'$n1_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n2_north_service_name/pipeline -d  '{"pipeline": ["'$n2_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n3_north_service_name/pipeline -d  '{"pipeline": ["'$n3_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n4_north_service_name/pipeline -d  '{"pipeline": ["'$n4_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n5_north_service_name/pipeline -d  '{"pipeline": ["'$n5_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n6_north_service_name/pipeline -d  '{"pipeline": ["'$n6_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n7_north_service_name/pipeline -d  '{"pipeline": ["'$n7_north_service_name'_'$plugin_1'"]}'
-curl -X PUT http://localhost:8081/fledge/filter/$n8_north_service_name/pipeline -d  '{"pipeline": ["'$n8_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n1_north_service_name/pipeline -d  '{"pipeline": ["'$n1_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n2_north_service_name/pipeline -d  '{"pipeline": ["'$n2_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n3_north_service_name/pipeline -d  '{"pipeline": ["'$n3_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n4_north_service_name/pipeline -d  '{"pipeline": ["'$n4_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n5_north_service_name/pipeline -d  '{"pipeline": ["'$n5_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n6_north_service_name/pipeline -d  '{"pipeline": ["'$n6_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n7_north_service_name/pipeline -d  '{"pipeline": ["'$n7_north_service_name'_'$plugin_1'"]}'
+curl_wrapper -X PUT http://localhost:8081/fledge/filter/$n8_north_service_name/pipeline -d  '{"pipeline": ["'$n8_north_service_name'_'$plugin_1'"]}'
 
 # Create control pipelines
 # Group 1.1
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n1_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_1_sp'","'$ctrl_filter_1_pd'"],"enabled":false,"name":"'$ctrl_pipeline_1'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n2_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_2_sp'","'$ctrl_filter_2_pd'"],"enabled":false,"name":"'$ctrl_pipeline_2'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n3_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_3_sp'","'$ctrl_filter_3_pd'"],"enabled":false,"name":"'$ctrl_pipeline_3'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n4_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_4_sp'","'$ctrl_filter_4_pd'"],"enabled":false,"name":"'$ctrl_pipeline_4'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n1_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_1_sp'","'$ctrl_filter_1_pd'"],"enabled":false,"name":"'$ctrl_pipeline_1'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n2_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_2_sp'","'$ctrl_filter_2_pd'"],"enabled":false,"name":"'$ctrl_pipeline_2'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n3_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_3_sp'","'$ctrl_filter_3_pd'"],"enabled":false,"name":"'$ctrl_pipeline_3'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n4_north_service_name'"},"destination":{"type":2,"name":"'$s1_south_service_name'"},"filters":["'$ctrl_filter_4_sp'","'$ctrl_filter_4_pd'"],"enabled":false,"name":"'$ctrl_pipeline_4'"}'
 # Group 1.2
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n1_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_5_sp'","'$ctrl_filter_5_pd'"],"enabled":false,"name":"'$ctrl_pipeline_5'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n2_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_6_sp'","'$ctrl_filter_6_pd'"],"enabled":false,"name":"'$ctrl_pipeline_6'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n3_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_7_sp'","'$ctrl_filter_7_pd'"],"enabled":false,"name":"'$ctrl_pipeline_7'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n4_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_8_sp'","'$ctrl_filter_8_pd'"],"enabled":false,"name":"'$ctrl_pipeline_8'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n1_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_5_sp'","'$ctrl_filter_5_pd'"],"enabled":false,"name":"'$ctrl_pipeline_5'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n2_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_6_sp'","'$ctrl_filter_6_pd'"],"enabled":false,"name":"'$ctrl_pipeline_6'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n3_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_7_sp'","'$ctrl_filter_7_pd'"],"enabled":false,"name":"'$ctrl_pipeline_7'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n4_north_service_name'"},"destination":{"type":2,"name":"'$s3_south_service_name'"},"filters":["'$ctrl_filter_8_sp'","'$ctrl_filter_8_pd'"],"enabled":false,"name":"'$ctrl_pipeline_8'"}'
 # Group 2.1
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n5_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_9_sp'","'$ctrl_filter_9_pd'"],"enabled":false,"name":"'$ctrl_pipeline_9'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n6_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_10_sp'","'$ctrl_filter_10_pd'"],"enabled":false,"name":"'$ctrl_pipeline_10'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n7_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_11_sp'","'$ctrl_filter_11_pd'"],"enabled":false,"name":"'$ctrl_pipeline_11'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n8_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_12_sp'","'$ctrl_filter_12_pd'"],"enabled":false,"name":"'$ctrl_pipeline_12'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n5_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_9_sp'","'$ctrl_filter_9_pd'"],"enabled":false,"name":"'$ctrl_pipeline_9'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n6_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_10_sp'","'$ctrl_filter_10_pd'"],"enabled":false,"name":"'$ctrl_pipeline_10'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n7_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_11_sp'","'$ctrl_filter_11_pd'"],"enabled":false,"name":"'$ctrl_pipeline_11'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n8_north_service_name'"},"destination":{"type":2,"name":"'$s2_south_service_name'"},"filters":["'$ctrl_filter_12_sp'","'$ctrl_filter_12_pd'"],"enabled":false,"name":"'$ctrl_pipeline_12'"}'
 # Group 2.2
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n5_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_13_sp'","'$ctrl_filter_13_pd'"],"enabled":false,"name":"'$ctrl_pipeline_13'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n6_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_14_sp'","'$ctrl_filter_14_pd'"],"enabled":false,"name":"'$ctrl_pipeline_14'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n7_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_15_sp'","'$ctrl_filter_15_pd'"],"enabled":false,"name":"'$ctrl_pipeline_15'"}'
-curl -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n8_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_16_sp'","'$ctrl_filter_16_pd'"],"enabled":false,"name":"'$ctrl_pipeline_16'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n5_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_13_sp'","'$ctrl_filter_13_pd'"],"enabled":false,"name":"'$ctrl_pipeline_13'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n6_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_14_sp'","'$ctrl_filter_14_pd'"],"enabled":false,"name":"'$ctrl_pipeline_14'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n7_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_15_sp'","'$ctrl_filter_15_pd'"],"enabled":false,"name":"'$ctrl_pipeline_15'"}'
+curl_wrapper -sX POST http://localhost:8081/fledge/control/pipeline -d '{"execution":"Shared","source":{"type":2,"name":"'$n8_north_service_name'"},"destination":{"type":2,"name":"'$s4_south_service_name'"},"filters":["'$ctrl_filter_16_sp'","'$ctrl_filter_16_pd'"],"enabled":false,"name":"'$ctrl_pipeline_16'"}'
 
 # Param advanced south
 sleep 5
 # setting south service max readings latency to 100 ms
-curl -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s1_south_service_name_advanced
-curl -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s2_south_service_name_advanced
-curl -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s3_south_service_name_advanced
-curl -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s4_south_service_name_advanced
+curl_wrapper -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s1_south_service_name_advanced
+curl_wrapper -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s2_south_service_name_advanced
+curl_wrapper -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s3_south_service_name_advanced
+curl_wrapper -X PUT --data '{"maxSendLatency":"100"}' http://localhost:8081/fledge/category/$s4_south_service_name_advanced
 # setting statistics to be collected at service level
-curl -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s1_south_service_name_advanced
-curl -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s2_south_service_name_advanced
-curl -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s3_south_service_name_advanced
-curl -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s4_south_service_name_advanced
+curl_wrapper -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s1_south_service_name_advanced
+curl_wrapper -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s2_south_service_name_advanced
+curl_wrapper -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s3_south_service_name_advanced
+curl_wrapper -X PUT --data '{"statistics":"per service"}' http://localhost:8081/fledge/category/$s4_south_service_name_advanced
 # setting audit tracker interval to 5 min
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s1_south_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s2_south_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s3_south_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s4_south_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n1_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n2_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n3_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n4_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n5_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n6_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n7_north_service_name_advanced
-curl -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n8_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s1_south_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s2_south_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s3_south_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$s4_south_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n1_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n2_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n3_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n4_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n5_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n6_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n7_north_service_name_advanced
+curl_wrapper -X PUT --data '{"assetTrackerInterval":"9999999"}' http://localhost:8081/fledge/category/$n8_north_service_name_advanced
 
 # Param storage layer
-curl -X PUT --data '{"readingPlugin":"sqlitememory"}' http://localhost:8081/fledge/category/Storage
+curl_wrapper -X PUT --data '{"readingPlugin":"sqlitememory"}' http://localhost:8081/fledge/category/Storage
 
 # Param purge
-curl -X PUT --data '{"value":"1"}' http://localhost:8081/fledge/category/PURGE_READ/age
-curl -X PUT --data '{"value":"100000"}' http://localhost:8081/fledge/category/PURGE_READ/size
+curl_wrapper -X PUT --data '{"value":"1"}' http://localhost:8081/fledge/category/PURGE_READ/age
+curl_wrapper -X PUT --data '{"value":"100000"}' http://localhost:8081/fledge/category/PURGE_READ/size
 
 # Create Notification plugins
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_1'","description":"'$notif_name_1' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_2'","description":"'$notif_name_2' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_3'","description":"'$notif_name_3' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
-curl -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_4'","description":"'$notif_name_4' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl_wrapper -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_1'","description":"'$notif_name_1' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl_wrapper -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_2'","description":"'$notif_name_2' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl_wrapper -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_3'","description":"'$notif_name_3' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
+curl_wrapper -sX POST http://localhost:8081/fledge/notification -d '{"name":"'$notif_name_4'","description":"'$notif_name_4' notification instance","rule":"'$notif_plugin_1'","channel":"'$notif_plugin_2'","notification_type":"retriggered","enabled":false,"retrigger_time":"0","rule_config":{},"delivery_config":{}}'
 
 # Restart Fledge as it is mandatory for control pipelines to work
-curl -X PUT http://localhost:8081/fledge/restart
+curl_wrapper -X PUT http://localhost:8081/fledge/restart

--- a/all-plugins-ubuntu2404/fledge/start.sh
+++ b/all-plugins-ubuntu2404/fledge/start.sh
@@ -14,10 +14,6 @@ if [ ! -z "$password_token" ]; then
     curl -X PUT http://localhost:8081/fledge/category/rest_api -d '{"authentication":"optional"}' -H "authorization: $password_token"
 fi
 
-# Redémarrage
-/usr/local/fledge/bin/fledge -u admin -p fledge stop
-/usr/local/fledge/bin/fledge start
-
 sleep 10
-sh importModules.sh
+sh importModules.sh $password_token
 tail -f /var/log/syslog


### PR DESCRIPTION
This pull request adresses the following points :

- The additionnal restart of Fledge was shown incompatible with utility package pmp-scripts v2.3.0
- The field "retrigger_time" of notification plugins no longer accepts "-1" as a value
- Control pipelines 13 to 16 incorrectly named since previous version